### PR TITLE
Fix issues on OpenCV  4.2

### DIFF
--- a/motion_heatmap.cpp
+++ b/motion_heatmap.cpp
@@ -12,7 +12,7 @@
 using namespace std;
 using namespace cv;
 
-void main()
+int main()
 {
 	//Capturing video
 	int option;
@@ -28,7 +28,7 @@ void main()
 		cout<<"Enter video file name (with extension): "; // input video should be on same worksapce folder
 		cin>>vid_file;
 		cap.open(vid_file);
-		nFrames = cap.get(CV_CAP_PROP_FRAME_COUNT);
+		nFrames = cap.get(CAP_PROP_FRAME_COUNT);
 	}
 	else
 		cout<<"enter valid option !"<<endl;
@@ -40,10 +40,10 @@ void main()
 	}
 
 	// Default resolution of the frame is obtained.The default resolution is system dependent.
-	int frame_width = cap.get(CV_CAP_PROP_FRAME_WIDTH) , frame_height = cap.get(CV_CAP_PROP_FRAME_HEIGHT);
+	int frame_width = cap.get(CAP_PROP_FRAME_WIDTH) , frame_height = cap.get(CAP_PROP_FRAME_HEIGHT);
 
 	//Video saving APIs
-	VideoWriter video2("heatmap_video.avi",CV_FOURCC('M','J','P','G'),10, Size(frame_width,frame_height));
+	VideoWriter video2("heatmap_video.avi",cv::VideoWriter::fourcc('M','J','P','G'),10, Size(frame_width,frame_height));
 
 	//begsegmentation pointer initialised
 	Ptr<BackgroundSubtractorMOG2> background_segmentor_object_file = createBackgroundSubtractorMOG2();
@@ -67,7 +67,7 @@ void main()
 			//Converting to Grayscale
 			cvtColor(frame,gray, COLOR_BGR2GRAY);
 			//accum_image frame dimension initialisation
-			Mat accum_image = Mat(frame_height,frame_width, CV_64F, double(0));
+			accum_image = Mat(frame_height,frame_width, CV_8U, double(0));
 			first_iteration_indicator=0;
 		}
 		else
@@ -79,7 +79,7 @@ void main()
 			background_segmentor_object_file ->apply(gray,fgbgmask);
 			//Thresholding the image
 			int thres=2,maxValue=2;
-			threshold(fgbgmask,threshold_image,thres,maxValue,CV_THRESH_BINARY);
+			threshold(fgbgmask,threshold_image,thres,maxValue,THRESH_BINARY);
 			//Adding to the accumilated image
 			accum_image = threshold_image+accum_image;
 			//Saving the accumilated image onto a duplicate frame to plot a live heatmap
@@ -121,5 +121,5 @@ void main()
 	cap.release();
 	// Closes all the windows
 	destroyAllWindows();
-
+    return 0;
 }


### PR DESCRIPTION

1. The main function requires `int` return type.
2. Change the constants compatible with the new OpenCV version. 

`CV_CAP_PROP_FRAME_COUNT` -> `CAP_PROP_FRAME_COUNT`
`CV_CAP_PROP_FRAME_WIDTH` -> `CAP_PROP_FRAME_WIDTH`
`CV_CAP_PROP_FRAME_HEIGHT` -> `CAP_PROP_FRAME_HEIGHT`
`CV_FOURCC` -> `cv::VideoWriter::fourcc` 
`CV_THRESH_BINARY` -> `THRESH_BINARY`

3. Bug Fix - Existing Code 

```
terminate called after throwing an instance of 'cv::Exception'
what():  OpenCV(4.2.0-dev) /home/sleebapaul/opencvInstallation/opencv/modules/core/src/matrix_expressions.cpp:31: error: 
(-5:Bad argument) One or more matrix operands are empty. in function 'checkOperandsExist'
```
- `accum_image` is defined again inside the `main` function despite it is declared globally.
- New assignment will set the `accum_image` to empty.

4. Bugfix - Existing code 

```
terminate called after throwing an instance of 'cv::Exception'
what():  OpenCV(4.2.0-dev) /home/sleebapaul/opencvInstallation/opencv/modules/core/src/arithm.cpp:693: error: 
(-5:Bad argument) When the input arrays in add/subtract/multiply/divide functions have different types, the output array type must be explicitly specified in function 'arithm_op'
```
- Fix 

- Both the images are coming from different `Mat` formats thus, need conversion.
```c++
accum_image = threshold_image+accum_image
```
So we may add the following conversion and then add two images. 
```c++
threshold_image.convertTo(threshold_image, CV_64F);
```

5. Derived from previous issue 4

```
terminate called after throwing an instance of 'cv::Exception'
what():  OpenCV(4.2.0-dev) /home/sleebapaul/opencvInstallation/opencv/modules/imgproc/src/colormap.cpp:714: error: 
(-5:Bad argument) cv::ColorMap only supports source images of type CV_8UC1 or CV_8UC3 in function 'operator()'
```

SInce `ColorMap` does support only `CV_8UC`,  the option is to first create the `accum_image` be of the format `CV_8U` rather than declaring it as a `CV_64F`. 

`accum_image = Mat(frame_height,frame_width, CV_8U, double(0));`

Now there is no need for a conversion which is discussed in point 4. 

 

